### PR TITLE
Fixed GCS access issues and migrated off container registry

### DIFF
--- a/build-app-images.yaml
+++ b/build-app-images.yaml
@@ -17,33 +17,33 @@ steps:
     args: 
       - build
       - -t
-      - gcr.io/$PROJECT_ID/dlp-runner
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_DOCKER_REPO_NAME}/dlp-runner
       - ./src/dlp-runner
     id: 1-docker-build-dlp-runner
   - name: gcr.io/cloud-builders/docker
     args:
       - build
       - -t
-      - gcr.io/$PROJECT_ID/findings-writer
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_DOCKER_REPO_NAME}/findings-writer
       - ./src/findings-writer
     id: 2-docker-build-findings-writer
   - name: gcr.io/cloud-builders/docker
     args:
       - build
       - -t
-      - gcr.io/$PROJECT_ID/pdf-merger
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_DOCKER_REPO_NAME}/pdf-merger
       - ./src/pdf-merger
     id: 3-docker-build-pdf-merger
   - name: gcr.io/cloud-builders/docker
     args:
       - build
       - -t
-      - gcr.io/$PROJECT_ID/pdf-splitter
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_DOCKER_REPO_NAME}/pdf-splitter
       - ./src/pdf-splitter
     id: 4-docker-build-pdf-splitter
 artifacts:
   images:
-    - 'gcr.io/$PROJECT_ID/dlp-runner'
-    - 'gcr.io/$PROJECT_ID/findings-writer'
-    - 'gcr.io/$PROJECT_ID/pdf-merger'
-    - 'gcr.io/$PROJECT_ID/pdf-splitter'
+    - '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_DOCKER_REPO_NAME}/dlp-runner'
+    - '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_DOCKER_REPO_NAME}/findings-writer'
+    - '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_DOCKER_REPO_NAME}/pdf-merger'
+    - '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_DOCKER_REPO_NAME}/pdf-splitter'

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -23,8 +23,8 @@ module "pdf_redactor" {
   region                = var.region
   wf_region             = var.wf_region
   suffix                = random_id.pdf_redaction.hex
-  image_dlp_runner      = "gcr.io/${var.project_id}/dlp-runner"
-  image_findings_writer = "gcr.io/${var.project_id}/findings-writer"
-  image_pdf_merger      = "gcr.io/${var.project_id}/pdf-merger"
-  image_pdf_splitter    = "gcr.io/${var.project_id}/pdf-splitter"
+  image_dlp_runner      = "${var.region}-docker.pkg.dev/${var.project_id}/${var.docker_repo_name}/dlp-runner"
+  image_findings_writer = "${var.region}-docker.pkg.dev/${var.project_id}/${var.docker_repo_name}/findings-writer"
+  image_pdf_merger      = "${var.region}-docker.pkg.dev/${var.project_id}/${var.docker_repo_name}/pdf-merger"
+  image_pdf_splitter    = "${var.region}-docker.pkg.dev/${var.project_id}/${var.docker_repo_name}/pdf-splitter"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -16,6 +16,10 @@ variable "project_id" {
   type        = string
   description = "Project ID"
 }
+variable "docker_repo_name" {
+  type        = string
+  description = "Docker Repo Name"
+}
 variable "region" {
   type        = string
   description = "GCP Region"


### PR DESCRIPTION
Google made [IAM changes to Cloud Build](https://cloud.google.com/build/docs/cloud-build-service-account-updates) which removed default permissions to GCS.
This PR provides deployment steps to overcome such changes.

Additionally, this PR also migrates off [legacy] Container Registry and on to Artifact Registry.